### PR TITLE
1.0.4: Fix chrome and edge plotly rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.4] - 2024-06-18
+
+### Fixed
+
+- Fixed required flag for Chrome and Edge Plotly rendering
+
 ## [1.0.3] - 2024-06-18
 
 ### Fixed

--- a/fermo_gui/fermo_gui/static/js/dashboard.js
+++ b/fermo_gui/fermo_gui/static/js/dashboard.js
@@ -52,7 +52,7 @@ document.addEventListener('DOMContentLoaded', function() {
     statsChromatogram = JSON.parse(chromatogramElement.getAttribute('data-stats-chromatogram'));
     statsNetwork = JSON.parse(networkElement.getAttribute('data-stats-network'));
     statsGroups = JSON.parse(groupElement.getAttribute('data-stats-groups'));
-    statsFIdGroups = JSON.parse(featureGroupElement.getAttribute('data-stats-fgroups'));
+    const statsFIdGroups = JSON.parse(featureGroupElement.getAttribute('data-stats-fgroups'));
 
     const firstSample = document.querySelector('.select-sample');
     if (firstSample) {

--- a/fermo_gui/pyproject.toml
+++ b/fermo_gui/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fermo_gui"
-version = "1.0.3"
+version = "1.0.4"
 description = "Visalization part of program FERMO"
 requires-python = ">=3.11,<3.12"
 license = {file = "LICENSE.md"}


### PR DESCRIPTION
## [1.0.4] - 2024-06-18

### Fixed

- Fixed required flag for Chrome and Edge Plotly rendering
