### PR TITLE
Increase version fermo_core to 0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [1.0.7] - 2024-07-10
+
+### Changed
+
+- Bumped version of `fermo_core` to `0.4.3`
+
 ## [1.0.7] - 2024-07-10
 
 ### Added
@@ -16,7 +23,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Job URLs: when job was started after loading old parameters, result URL was malformed
 - Nginx config: fixed default upload file size
 - Dashboard: clarified download field names
-
 
 ## [1.0.6] - 2024-06-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [1.0.7] - 2024-07-10
+## [1.0.8] - 2024-07-23
 
 ### Changed
 

--- a/fermo_gui/pyproject.toml
+++ b/fermo_gui/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fermo_gui"
-version = "1.0.7"
+version = "1.0.8"
 description = "Visalization part of program FERMO"
 requires-python = ">=3.11,<3.12"
 license = {file = "LICENSE.md"}


### PR DESCRIPTION
## [1.0.8] - 2024-07-23

### Changed

- Bumped version of `fermo_core` to `0.4.3`