### PR TITLE
1.0.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.9] - 2024-07-24
+
+### Fixed
+
+- Fixed increase of version of `fermo_core` to `0.4.3`
+
 ## [1.0.8] - 2024-07-23
 
 ### Changed

--- a/fermo_gui/pyproject.toml
+++ b/fermo_gui/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fermo_gui"
-version = "1.0.8"
+version = "1.0.9"
 description = "Visalization part of program FERMO"
 requires-python = ">=3.11,<3.12"
 license = {file = "LICENSE.md"}
@@ -25,7 +25,7 @@ dependencies = [
     "celery[redis]==5.2.7",
     "coloredlogs==15.0.1",
     "email-validator==2.1.0.post1",
-    "fermo_core==0.4.2",
+    "fermo_core==0.4.3",
     "Flask==3.0.1",
     "Flask-WTF==1.2.1",
     "Flask-Mail==0.9.1",


### PR DESCRIPTION
## [1.0.9] - 2024-07-24

### Fixed

- Fixed increase of version of `fermo_core` to `0.4.3`