### PR TITLE
Fixed docker build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.3] - 2025-11-04
+
+### Fixed
+
+- Updated docker base image `python:3.11-slim-buster` to `python:3.11-slim-bookworm` to fix failing builds
+
 ## [1.1.2] - 2025-05-14
 
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim-buster
+FROM python:3.11-slim-bookworm
 
 ENV PYTHONUNBUFFERED 1
 

--- a/compose/fermo_gui/Dockerfile
+++ b/compose/fermo_gui/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim-buster
+FROM python:3.11-slim-bookworm
 
 ENV PYTHONUNBUFFERED 1
 

--- a/fermo_gui/pyproject.toml
+++ b/fermo_gui/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fermo_gui"
-version = "1.1.2"
+version = "1.1.3"
 description = "Visalization part of program FERMO"
 requires-python = ">=3.11,<3.12"
 authors = [


### PR DESCRIPTION
## [1.1.3] - 2025-11-04

### Fixed

- Updated docker base image `python:3.11-slim-buster` to `python:3.11-slim-bookworm` to fix failing builds